### PR TITLE
VF-769 - Configure Subgroup Notifications

### DIFF
--- a/Notifications - Enable Group Notifications/Notification Policy.json
+++ b/Notifications - Enable Group Notifications/Notification Policy.json
@@ -3,12 +3,13 @@
     {
         "Snippet":
         {
-            "Use Case": "Enable groups to be notified when they are specified instead of a named approver.",
+            "Use Case": "Enable groups and subgroups to be notified when they are specified instead of a named approver.",
             "Example": "Send a notification to the entire group when no specific user is selected for an approval task.",
             "Comments": [
                 "Add the Notify Group element to the Notification Type definition.",
                 "The property will determine if the notification is sent to the group or not.",
-                "Setting the property to Yes will enable the group email. Setting the property to No or if it is missing, will disable the group email."
+                "Setting the property to Yes will enable the group email. Setting the property to No or if it is missing, will disable the group email.",
+                "Because the 'Notify Subgroup' property is not used, the 'Notify Group' property controls both group and subgroup notifications."
             ],
             "Minimum Required VERA Version": "2.8"
         },

--- a/Notifications - Enable Subgroup Notifications/Notification Policy.json
+++ b/Notifications - Enable Subgroup Notifications/Notification Policy.json
@@ -20,7 +20,7 @@
                 "Default Status": "Enabled",
                 "Record Types": ["Risk Requirement", "Requirement", "Test Case", "Defect", "Test Run", "Test Set"],
                 "Delivery Types": ["Email"],
-                "Notify Subroup": "Yes"
+                "Notify Subgroup": "Yes"
             }
         ]
     }

--- a/Notifications - Enable Subgroup Notifications/Notification Policy.json
+++ b/Notifications - Enable Subgroup Notifications/Notification Policy.json
@@ -1,0 +1,27 @@
+{
+    "Notification Policy":
+    {
+        "Snippet":
+        {
+            "Use Case": "Enable notifications to subgroups without enabling notifications to groups.",
+            "Example": "Send a notification to an entire subggroup when the task is assigned to a subgroup.  Do not send a notification when an entire group is assigned.",
+            "Comments": [
+                "Add the 'Notify Subgroup' element to the Notification Type definition.",
+                "The property will determine whether notifications are sent to approval subgroups.",
+                "Setting the property to 'Yes' will enable subgroup notifications. Setting the property to 'No' will disable subgroup notifications.",
+                "If the 'Notify Subgroup' property is not configured, then subgroup notifications will follow the configuration for group notifications."
+            ],
+            "Minimum Required VERA Version": "2.9"
+        },
+        "Notification Types": [
+            {
+                "Name": "Task",
+                "Recipient": "Assignee",
+                "Default Status": "Enabled",
+                "Record Types": ["Risk Requirement", "Requirement", "Test Case", "Defect", "Test Run", "Test Set"],
+                "Delivery Types": ["Email"],
+                "Notify Subroup": "Yes"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Updated the snippets to describe enabling subgroup notifications without enabling group notifications.